### PR TITLE
Add Off Grid - on-device LLM app for iOS & Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This section showcases frameworks and contributions for supporting LLM inference
     - [Sherpa](https://github.com/Bip-Rep/sherpa): Android frontend for llama.cpp
     - [iAkashPaul/Portal](https://github.com/iakashpaul/portal): Wraps the example android app with tweaked UI, configs & additional model support
     - [dusty-nv's llama.cpp](https://github.com/dusty-nv/jetson-containers/tree/master/packages/llm/llama_cpp): Containers for Jetson deployment of llama.cpp
+    - [Off Grid](https://github.com/alichherawalla/off-grid-mobile): Open-source React Native app for on-device LLM chat, vision models (SmolVLM, LLaVA), and Stable Diffusion image generation on iOS & Android.
 - [MLC-LLM](https://github.com/mlc-ai/mlc-llm): MLC LLM is a machine learning compiler and high-performance deployment engine for large language models. Supports various platforms and build on top of TVM.
     - [Android App](https://llm.mlc.ai/#android): MLC Android app
     - [iOS App](https://llm.mlc.ai/#ios): MLC iOS app


### PR DESCRIPTION
Adds [Off Grid](https://github.com/alichherawalla/off-grid-mobile) to the deployment frameworks section under llama.cpp.

Off Grid is an open-source React Native app that runs LLMs on mobile devices using llama.cpp for inference. It also supports vision models (SmolVLM, LLaVA) and on-device image generation via Core ML Stable Diffusion on iOS.

### Key Details
- **Platform**: iOS & Android (React Native)
- **Inference**: llama.cpp (GGUF models)
- **Vision**: SmolVLM, LLaVA
- **Image Gen**: Core ML Stable Diffusion (iOS)
- **Fully offline** — no cloud, no API keys

### Download
- [App Store](https://apps.apple.com/in/app/off-grid-on-device-ai/id6740649499)
- [Google Play](https://play.google.com/store/apps/details?id=ai.offgridmobile)
- [APK](https://github.com/alichherawalla/off-grid-mobile/releases)