### PR TITLE
Add OneComp: mixed-precision PTQ for edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ This section focuses on measurements and benchmarking efforts for assessing LLM 
 
 ## Mobile-Specific Optimisations
 
+- [OneComp (arXiv:2603.28845)](https://arxiv.org/abs/2603.28845) — Fujitsu Research's ILP-based mixed-precision PTQ (AutoBit) automatically estimates bitwidth from available VRAM, fitting mobile/edge deployment budgets. [Code](https://github.com/FujitsuResearch/OneCompression).
+
 This section focuses on techniques and optimisations that target mobile-specific deployment.
 
 ### Papers


### PR DESCRIPTION
## Summary

This PR adds **OneComp** (Fujitsu Research, [arXiv:2603.28845](https://arxiv.org/abs/2603.28845)) and its accompanying NeurIPS 2025 paper **QEP** to this awesome list.

OneComp is an open-source, Apache-2.0 licensed post-training quantization (PTQ) framework for LLMs that unifies several recent research directions behind a single `Runner.auto_run()` API:

- **QEP** (Quantization Error Propagation, NeurIPS 2025) — layer-wise PTQ with propagated error compensation.
- **AutoBit** — ILP-based mixed-precision bitwidth assignment derived from available VRAM.
- **JointQ** — joint weight–scale optimization (group-wise 4-bit, etc.).
- **Rotation preprocessing** — SpinQuant/OstQuant-style learned rotations absorbed into weights, with online Hadamard hooks at load time.
- **LoRA SFT post-process** — accuracy recovery / knowledge injection after quantization.
- **vLLM plugin** — first-class DBF & Mixed-GPTQ serving of OneComp checkpoints.

Verified on Llama (TinyLlama / Llama-2 / Llama-3) and Qwen3 (0.6B — 32B). PyPI: `pip install onecomp`.

Links:
- Repo: https://github.com/FujitsuResearch/OneCompression
- Paper (OneComp): https://arxiv.org/abs/2603.28845
- Paper (QEP, NeurIPS 2025): https://openreview.net/forum?id=a3l3K9khbL
- Docs: https://FujitsuResearch.github.io/OneCompression/

Happy to adjust section placement, wording, or formatting to better match the list's conventions — thanks for maintaining this resource!
